### PR TITLE
Fix journalctl interactive spec

### DIFF
--- a/journalctl-mode.el
+++ b/journalctl-mode.el
@@ -648,9 +648,7 @@ ring for the time range of the selected region."
 
 With COMMAND and with prefix ARG, prompt for editing the command."
   (interactive
-   (list
-    (read-shell-command "Journalctl command: " (car jcm-history) 'jcm-history)
-    current-prefix-arg))
+   (list (read-shell-command "Journalctl command: " (car jcm-history) 'jcm-history)))
   (when current-prefix-arg
     (setq command (read-shell-command "Journalctl command: " command 'jcm-history)))
   (let ((remote-host (file-remote-p default-directory)))


### PR DESCRIPTION
The function only takes one argument, so the interactive spec needs to specify exactly one argument.