### PR TITLE
Check if symbol-overlay-mode is bound, instead of checking the feature

### DIFF
--- a/journalctl.el
+++ b/journalctl.el
@@ -622,7 +622,7 @@ ring for the time range of the selected region."
   "Major mode for browsing journald records with `journalctl'.
 
 \\{journalctl-mode-map}"
-  (when (featurep 'symbol-overlay)
+  (when (fboundp 'symbol-overlay-mode)
     (symbol-overlay-mode))
   ;; visual-line makes sense for messages to flow nicely
   (visual-line-mode))


### PR DESCRIPTION
1. This works when symbol-overlay-mode is available (via autoload) but hasn't been loaded yet.
2. This silences the byte-compiler warnings.