### PR TITLE
Inhibit read-only on insert

### DIFF
--- a/journalctl.el
+++ b/journalctl.el
@@ -427,7 +427,8 @@ bear this in mind."
     (if (not (buffer-live-p target-buffer))
         (when (process-live-p process) (kill-process process))
       (with-current-buffer target-buffer
-        (let ((return-end (eq (point) (point-max))))
+        (let ((return-end (eq (point) (point-max)))
+              (inhibit-read-only t))
           (save-excursion
             (widen)
             (journalctl--goto-insertion-point process record)


### PR DESCRIPTION
This way the user can enable `read-only-mode` if desired to avoid accidentally editing the journal buffer.

NOTE: this does _not_ set `buffer-read-only` as users may prefer to keep the buffer editable. If the user wants the buffer to be read-only, they can add `read-only-mode` to the `journalctl-mode-hook`.